### PR TITLE
Loading ICC profiles at runtime

### DIFF
--- a/src/profile.rs
+++ b/src/profile.rs
@@ -8,15 +8,15 @@ use std::ffi::CString;
 use std::default::Default;
 
 impl Profile {
-	pub fn new_from_file(path: &str) -> Option<Profile> {
-		if let Ok(path) = CString::new(path){
-			return Self::new_handle(unsafe {
-				ffi::cmsOpenProfileFromFile(path.as_ptr(), CString::new("r").unwrap().as_ptr())
-			});
-		}
+    pub fn new_from_file(path: &str) -> Option<Profile> {
+        if let Ok(path) = CString::new(path){
+            return Self::new_handle(unsafe {
+                ffi::cmsOpenProfileFromFile(path.as_ptr(), CString::new("r").unwrap().as_ptr())
+            });
+        }
 
-		None
-	}
+        None
+    }
 
     pub fn new_icc(data: &[u8]) -> Option<Profile> {
         Self::new_handle(unsafe {
@@ -256,5 +256,7 @@ fn bad_icc() {
 
 #[test]
 fn load_icc_runtime() {
-	assert!(Profile::new_from_file("tests/gray18.icc").is_some());
+    assert!(Profile::new_from_file("tests/gray18.icc").is_some());
+    assert!(Profile::new_from_file("löasdkfj.icc").is_none());
+    assert!(Profile::new_from_file("").is_none());
 }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -8,6 +8,16 @@ use std::ffi::CString;
 use std::default::Default;
 
 impl Profile {
+	pub fn new_from_file(path: &str) -> Option<Profile> {
+		if let Ok(path) = CString::new(path){
+			return Self::new_handle(unsafe {
+				ffi::cmsOpenProfileFromFile(path.as_ptr(), CString::new("r").unwrap().as_ptr())
+			});
+		}
+
+		None
+	}
+
     pub fn new_icc(data: &[u8]) -> Option<Profile> {
         Self::new_handle(unsafe {
             ffi::cmsOpenProfileFromMem(data.as_ptr() as *const c_void, data.len() as u32)
@@ -242,4 +252,9 @@ fn icc() {
 fn bad_icc() {
     let err = Profile::new_icc(&[1,2,3]);
     assert!(err.is_none());
+}
+
+#[test]
+fn load_icc_runtime() {
+	assert!(Profile::new_from_file("tests/gray18.icc").is_some());
 }


### PR DESCRIPTION
This PR adds support for adding an ICC color profile at runtime using the cmsOpenProfileFromFile function. In my application, I need to load color profiles from a clients computer, so I cannot use `include_bytes!`, since I don't know the profile they have.

Since the whole crate is undocumented, I have not added documentation either. I hope that's OK.

The test run fine, but the last test in transform.rs crashes. I had it disabled when I ran my tests.