### PR TITLE
tag: Add VCGT value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@ pub enum Tag<'a> {
     Technology(ffi::TechnologySignature),
     ToneCurve(&'a ToneCurveRef),
     UcrBg(&'a ffi::UcrBg),
+    VcgtCurves([&'a ToneCurveRef; 3]),
     /// Unknown format or missing data
     None,
 }

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -99,6 +99,7 @@ impl<'a> Tag<'a> {
             },
             (ScreeningTag, &Tag::Screening(data)) => data as *const _ as *const u8,
             (UcrBgTag, &Tag::UcrBg(data)) => data as *const _ as *const u8,
+            (VcgtTag, &Tag::VcgtCurves(arr)) => arr[0].as_ptr() as *const _,
             (ViewingConditionsTag, &Tag::ICCViewingConditions(data)) => {
                 data as *const _ as *const u8
             },
@@ -174,6 +175,11 @@ impl<'a> Tag<'a> {
             ProfileSequenceIdTag => Tag::SEQ(cast(data)),
             ScreeningTag => Tag::Screening(cast(data)),
             UcrBgTag => Tag::UcrBg(cast(data)),
+            VcgtTag => Tag::VcgtCurves([
+                ToneCurveRef::from_ptr(aligned_mut(data)),
+                ToneCurveRef::from_ptr(*(aligned_mut::<*mut ffi::ToneCurve>(data).offset(1))),
+                ToneCurveRef::from_ptr(*(aligned_mut::<*mut ffi::ToneCurve>(data).offset(2))),
+            ]),
             ViewingConditionsTag => Tag::ICCViewingConditions(cast(data)),
             _ => Tag::None,
         }


### PR DESCRIPTION
While lcms2-sys knows the VCGT-tag, there is currently no way to read it using these bindings. This PR fixes that.