### PR TITLE
Bind additional functions for creating profiles with CICP tags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,3 +107,19 @@ pub fn version() -> u32 {
     };
     if ok { Some(res) } else { None }
 }
+
+pub fn xyY2XYZ(xyY: &CIExyY) -> CIEXYZ {
+    let mut xyz = CIEXYZ::default();
+    unsafe {
+        crate::ffi::cmsxyY2XYZ(std::ptr::addr_of_mut!(xyz), std::ptr::addr_of!(*xyY))
+    }
+    xyz
+}
+
+pub fn XYZ2xyY(xyz: &CIEXYZ) -> CIExyY {
+    let mut xyY = CIExyY::default();
+    unsafe {
+        crate::ffi::cmsXYZ2xyY(std::ptr::addr_of_mut!(xyY), std::ptr::addr_of!(*xyz))
+    }
+    xyY
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ pub use crate::ffi::Intent;
 pub use crate::ffi::ColorSpaceSignature;
 pub use crate::ffi::ProfileClassSignature;
 pub use crate::ffi::ViewingConditions;
+pub use crate::ffi::VideoSignalType;
 
 #[derive(Debug)]
 #[non_exhaustive]
@@ -80,6 +81,7 @@ pub enum Tag<'a> {
     ToneCurve(&'a ToneCurveRef),
     UcrBg(&'a ffi::UcrBg),
     VcgtCurves([&'a ToneCurveRef; 3]),
+    VideoSignal(&'a ffi::VideoSignalType),
     /// Unknown format or missing data
     None,
 }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -454,6 +454,14 @@ impl<Ctx: Context> Profile<Ctx> {
             ffi::cmsSetHeaderProfileID(self.handle, &id as *const ffi::ProfileID as *mut _);
         }
     }
+
+    pub fn save_profile_to_file(&mut self, path: &str) {
+        unsafe {
+            let path_c_str = std::ffi::CString::new(path).expect("path cannot be converted to a null-terminated C string");
+            let ret = ffi::cmsSaveProfileToFile(self.handle, path_c_str.as_ptr());
+            if ret == 0 { panic!() }
+        }
+    }
 }
 
 /// Per-context functions that can be used with a `ThreadContext`

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -103,6 +103,9 @@ impl<'a> Tag<'a> {
             (ViewingConditionsTag, &Tag::ICCViewingConditions(data)) => {
                 data as *const _ as *const u8
             },
+            (CicpTag, &Tag::VideoSignal(data)) => {
+                data as *const _ as *const u8
+            },
             (sig, _) => panic!("Signature type {:?} does not support this tag data type", sig),
         }
     }


### PR DESCRIPTION
Hello,

I found myself needing some additional functions from LittleCMS that weren't bound in the bindings while doing experiments with the relatively new CICP ICC tags.

I'm not quite used to Rust code style yet - in particular I'm unsure about:

* error handling in the `save_profile_to_file` function where `panic!` probably isn't the right response
* should the `xyY2XYZ` function and its inverse be placed in the main module or somewhere else?

Hope you don't mind this PR anyway!