### PR TITLE
Fixed improper use of as_ptr()

### DIFF
--- a/src/mlu.rs
+++ b/src/mlu.rs
@@ -82,7 +82,7 @@ impl MLURef {
                 self.as_ptr(),
                 locale.language_ptr(),
                 locale.country_ptr(),
-                buf[..].as_ptr() as *mut _,
+                buf[..].as_mut_ptr() as *mut _,
                 len,
             );
             if let Some(0) = buf.pop() { // terminating zero
@@ -114,7 +114,7 @@ impl MLURef {
                 self.as_ptr(),
                 locale.language_ptr(),
                 locale.country_ptr(),
-                buf[..].as_ptr() as *mut wchar_t,
+                buf[..].as_mut_ptr() as *mut wchar_t,
                 len_bytes,
             );
             if let Some(0) = buf.pop() { // terminating zero


### PR DESCRIPTION
This fixes two instances where an immutable pointer to a `Vec<u8>` is being converted to a mutable pointer and then mutated in C.